### PR TITLE
npm update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2115,9 +2115,9 @@
       }
     },
     "node_modules/nostr-tools": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-1.8.3.tgz",
-      "integrity": "sha512-0giVDk0ElhqlGY032ma/8Q8NsIyFL53fCCkndFCpuLabZ2E134Kth0sbnIIIFXLqm7VnYIlgLVtCna8+dUiZUg==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-1.8.4.tgz",
+      "integrity": "sha512-oaRgZ8jpLmkMgtvhH9jbUI0k6XeXAUXSDv7qYBNwnIonfWYYZ0C19snJv1YRS+GWGf2gJ8ePJkXMJWlcsNR2yA==",
       "dependencies": {
         "@noble/hashes": "1.2.0",
         "@noble/secp256k1": "1.7.0",


### PR DESCRIPTION
### npm outdated
```
Package              Current  Wanted  Latest  Location                          Depended by
@vitest/coverage-c8   0.29.8  0.29.8  0.30.1  node_modules/@vitest/coverage-c8  nostr-vercel-api
nostr-tools            1.8.3   1.8.4   1.8.4  node_modules/nostr-tools          nostr-vercel-api
vitest                0.29.8  0.29.8  0.30.1  node_modules/vitest               nostr-vercel-api
```
### npm update
```
changed 1 package, and audited 239 packages in 6s

found 0 vulnerabilities
```