### PR TITLE
npm update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2975,9 +2975,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.5.tgz",
-      "integrity": "sha512-0gEnL9wiRFxgz40o/i/eTBwm+NEbpUeTWhzKrZDSdKm6nplj+z4lKz8ANDgildxHm47Vg8EUia0aicKbawUVVA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.6.tgz",
+      "integrity": "sha512-cqIyLSbA6gornMS659AXTVKF7cvSHMdKmJJwQ9DXq3lwsT1uZSdktuBRlpHQ8VnOWx0QHtjDwxPpGtyo9Fh/Qg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.17.5",


### PR DESCRIPTION
### npm outdated
```
Package              Current  Wanted  Latest  Location                          Depended by
@vitest/coverage-c8   0.30.1  0.30.1  0.31.0  node_modules/@vitest/coverage-c8  nostr-vercel-api
vitest                0.30.1  0.30.1  0.31.0  node_modules/vitest               nostr-vercel-api
```
### npm update
```
changed 1 package, and audited 242 packages in 8s

found 0 vulnerabilities
```