### PR TITLE
npm update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,27 +38,51 @@
       }
     },
     "node_modules/@edge-runtime/format": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/format/-/format-2.0.1.tgz",
-      "integrity": "sha512-aE+9DtBvQyg349srixtXEUNauWtIv5HTKPy8Q9dvG1NvpldVIvvhcDBI+SuvDVM8kQl8phbYnp2NTNloBCn/Yg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/format/-/format-2.1.0.tgz",
+      "integrity": "sha512-gc2qbYEIIJRczBApBPznVI1c5vZgzrZQOsFZnAxxFiYah9qldHiu1YEitzSvXI8X8ZgvAguuIiyIbpWz17nlXA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@edge-runtime/node-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/node-utils/-/node-utils-2.0.3.tgz",
+      "integrity": "sha512-JUSbi5xu/A8+D2t9B9wfirCI1J8n8q0660FfmqZgA+n3RqxD3y7SnamL1sKRE5/AbHsKs9zcqCbK2YDklbc9Bg==",
       "dev": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@edge-runtime/primitives": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-2.0.0.tgz",
-      "integrity": "sha512-AXqUq1zruTJAICrllUvZcgciIcEGHdF6KJ3r6FM0n4k8LpFxZ62tPWVIJ9HKm+xt+ncTBUZxwgUaQ73QMUQEKw==",
-      "dev": true
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-2.1.2.tgz",
+      "integrity": "sha512-SR04SMDybALlhIYIi0hiuEUwIl0b7Sn+RKwQkX6hydg4+AKMzBNDFhj2nqHDD1+xkHArV9EhmJIb6iGjShwSzg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@edge-runtime/vm": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-2.0.0.tgz",
-      "integrity": "sha512-BOLrAX8IWHRXu1siZocwLguKJPEUv7cr+rG8tI4hvHgMdIsBWHJlLeB8EjuUVnIURFrUiM49lVKn8DRrECmngw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.0.1.tgz",
+      "integrity": "sha512-69twXLIcqVx0iNlc1vFqnXgka2CZi2c/QBAmMzXBk0M6mPG+ICCBh2dd+cv1K+HW2pfLuSW+EskkFXWGeCf1Vw==",
       "dev": true,
       "dependencies": {
-        "@edge-runtime/primitives": "2.0.0"
+        "@edge-runtime/primitives": "3.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@edge-runtime/vm/node_modules/@edge-runtime/primitives": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-3.0.1.tgz",
+      "integrity": "sha512-l5NNDcPkKW4N6qRmB8zzpCF6uRW1S808V/zm72z7b/aWwZUYbmEPPkzyhGAW0aQxLU1pGdZ8u2gNjamdaU6RXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -677,27 +701,28 @@
       "dev": true
     },
     "node_modules/@vercel/node": {
-      "version": "2.14.5",
-      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-2.14.5.tgz",
-      "integrity": "sha512-0vzzeIheLWSxoF/1zMG8GwZxdxOvNLRgDMlClljCqiSa5MIXtTsmCj93JHeYo6BWgvIbiR5XrD0vt2IYqFQCug==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-2.15.2.tgz",
+      "integrity": "sha512-1Dn4hdQY/ErHXOB0+h3I0zIlqAb6/2LRBi+8Od+MYG8ooGKkTsK+j9IPWVBWn6ycBsM0eeNTIhqgYSGTYbMjMw==",
       "dev": true,
       "dependencies": {
-        "@edge-runtime/vm": "2.0.0",
+        "@edge-runtime/node-utils": "2.0.3",
+        "@edge-runtime/primitives": "2.1.2",
+        "@edge-runtime/vm": "3.0.1",
         "@types/node": "14.18.33",
         "@types/node-fetch": "2.6.3",
         "@vercel/build-utils": "6.7.5",
         "@vercel/error-utils": "1.0.10",
         "@vercel/static-config": "2.0.17",
         "async-listen": "3.0.0",
-        "edge-runtime": "2.1.4",
+        "edge-runtime": "2.4.3",
         "esbuild": "0.14.47",
         "exit-hook": "2.2.1",
         "node-fetch": "2.6.9",
         "path-to-regexp": "6.2.1",
         "ts-morph": "12.0.0",
         "ts-node": "10.9.1",
-        "typescript": "4.9.5",
-        "ws": "8.13.0"
+        "typescript": "4.9.5"
       }
     },
     "node_modules/@vercel/static-config": {
@@ -810,9 +835,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
+      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1091,9 +1116,9 @@
       }
     },
     "node_modules/concordance/node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -1209,19 +1234,19 @@
       }
     },
     "node_modules/edge-runtime": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/edge-runtime/-/edge-runtime-2.1.4.tgz",
-      "integrity": "sha512-SertKByzAmjm+MkLbFl1q0ko+/90V24dhZgQM8fcdguQaDYVEVtb6okEBGeg8IQgL1/JUP8oSlUIxSI/bvsVRQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/edge-runtime/-/edge-runtime-2.4.3.tgz",
+      "integrity": "sha512-Amv/P+OJhxopvoVXFr7UXAKheBpdLeCcdR5Vw4GSdNFDWVny9sioQbczjEKPLER5WsMXl17P+llS011Xftducw==",
       "dev": true,
       "dependencies": {
-        "@edge-runtime/format": "2.0.1",
-        "@edge-runtime/vm": "2.1.2",
-        "async-listen": "2.0.3",
-        "exit-hook": "2.2.1",
+        "@edge-runtime/format": "2.1.0",
+        "@edge-runtime/vm": "3.0.3",
+        "async-listen": "3.0.0",
         "mri": "1.2.0",
         "picocolors": "1.0.0",
         "pretty-bytes": "5.6.0",
         "pretty-ms": "7.0.1",
+        "signal-exit": "4.0.2",
         "time-span": "4.0.0"
       },
       "bin": {
@@ -1232,33 +1257,24 @@
       }
     },
     "node_modules/edge-runtime/node_modules/@edge-runtime/primitives": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-2.1.2.tgz",
-      "integrity": "sha512-SR04SMDybALlhIYIi0hiuEUwIl0b7Sn+RKwQkX6hydg4+AKMzBNDFhj2nqHDD1+xkHArV9EhmJIb6iGjShwSzg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-3.0.3.tgz",
+      "integrity": "sha512-YnfMWMRQABAH8IsnFMJWMW+SyB4ZeYBPnR7V0aqdnew7Pq60cbH5DyFjS/FhiLwvHQk9wBREmXD7PP0HooEQ1A==",
       "dev": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/edge-runtime/node_modules/@edge-runtime/vm": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-2.1.2.tgz",
-      "integrity": "sha512-j4H5S26NJhYOyjVMN8T/YJuwwslfnEX1P0j6N2Rq1FaubgNowdYunA9nlO7lg8Rgjv6dqJ2zKuM7GD1HFtNSGw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.0.3.tgz",
+      "integrity": "sha512-SPfI1JeIRNs/4EEE2Oc0X6gG3RqjD1TnKu2lwmwFXq0435xgZGKhc3UiKkYAdoMn2dNFD73nlabMKHBRoMRpxg==",
       "dev": true,
       "dependencies": {
-        "@edge-runtime/primitives": "2.1.2"
+        "@edge-runtime/primitives": "3.0.3"
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/edge-runtime/node_modules/async-listen": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-2.0.3.tgz",
-      "integrity": "sha512-WVLi/FGIQaXyfYyNvmkwKT1RZbkzszLLnmW/gFCc5lbVvN/0QQCWpBwRBk2OWSdkkmKRBc8yD6BrKsjA3XKaSw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/emoji-regex": {
@@ -1776,6 +1792,12 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
     "node_modules/form-data": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -2175,13 +2197,13 @@
       }
     },
     "node_modules/mlly": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.3.0.tgz",
-      "integrity": "sha512-HT5mcgIQKkOrZecOjOX3DJorTikWXwsBfpcr/MGBkhfWcjiqvnaL/9ppxvIUXfjT6xt4DVIAsN9fMUz1ev4bIw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.0.tgz",
+      "integrity": "sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.8.2",
-        "pathe": "^1.1.0",
+        "acorn": "^8.9.0",
+        "pathe": "^1.1.1",
         "pkg-types": "^1.0.3",
         "ufo": "^1.1.2"
       }
@@ -2255,9 +2277,9 @@
       }
     },
     "node_modules/nostr-tools": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-1.11.1.tgz",
-      "integrity": "sha512-b8BpCiD3wxjBZwrn0wc+CkVj6/7s4sQxp+Az7UkCG80mJu7xTspZsOoUP/geBNwZVYETzEwj+CPBvW8WIP8mBQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-1.12.0.tgz",
+      "integrity": "sha512-fsIXaNJPKaSrO9MxsCEWbhI4tG4pToQK4D4sgLRD0fRDfZ6ocCg8CLlh9lcNx0o8pVErCMLVASxbJ+w4WNK0MA==",
       "dependencies": {
         "@noble/curves": "1.0.0",
         "@noble/hashes": "1.3.0",
@@ -2561,9 +2583,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.23.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.23.1.tgz",
-      "integrity": "sha512-ybRdFVHOoljGEFILHLd2g/qateqUdjE6YS41WXq4p3C/WwD3xtWxV4FYWETA1u9TeXQc5K8L8zHE5d/scOvrOQ==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.25.2.tgz",
+      "integrity": "sha512-VLnkxZMDr3jpxgtmS8pQZ0UvhslmF4ADq/9w4erkctbgjCqLW9oa89fJuXEs4ZmgyoF7Dm8rMDKSS5b5u2hHUg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2636,10 +2658,16 @@
       "dev": true
     },
     "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
+      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -3307,27 +3335,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
-    },
-    "node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",


### PR DESCRIPTION
### npm outdated
```
Package              Current  Wanted  Latest  Location                          Depended by
@vercel/node          2.14.5  2.15.2  2.15.2  node_modules/@vercel/node         nostr-vercel-api
@vitest/coverage-c8   0.30.1  0.30.1  0.32.2  node_modules/@vitest/coverage-c8  nostr-vercel-api
nostr-tools           1.11.1  1.12.0  1.12.0  node_modules/nostr-tools          nostr-vercel-api
vitest                0.30.1  0.30.1  0.32.2  node_modules/vitest               nostr-vercel-api
```
### npm update
```
added 3 packages, removed 2 packages, changed 13 packages, and audited 243 packages in 14s

6 moderate severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
```