### PR TITLE
npm update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2593,9 +2593,9 @@
       }
     },
     "node_modules/fdir": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
-      "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3253,9 +3253,9 @@
       }
     },
     "node_modules/nostr-tools": {
-      "version": "2.14.3",
-      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.14.3.tgz",
-      "integrity": "sha512-nk3h/V+JJ4YPIy77insbFjz80hWNEpicUGMXzF3YCM/CSx9aBzeGv766dEpIfIwtGg/yDvTTFS9qUBg5Ouk4/A==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.15.0.tgz",
+      "integrity": "sha512-Jj/+UFbu3JbTAWP4ipPFNuyD4W5eVRBNAP+kmnoRCYp3bLmTrlQ0Qhs5O1xSQJTFpjdZqoS0zZOUKdxUdjc+pw==",
       "license": "Unlicense",
       "dependencies": {
         "@noble/ciphers": "^0.5.1",


### PR DESCRIPTION
### npm outdated
```
Package      Current  Wanted  Latest  Location                  Depended by
nostr-tools   2.14.3  2.15.0  2.15.0  node_modules/nostr-tools  nostr-vercel-api
```
### npm update
```
changed 2 packages, and audited 370 packages in 9s

11 low severity vulnerabilities

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
```